### PR TITLE
Fix more 9 0 delete behaviour

### DIFF
--- a/spec/gitlab/client/branch_spec.cr
+++ b/spec/gitlab/client/branch_spec.cr
@@ -57,7 +57,13 @@ describe Gitlab::Client::Branch do
       branch = client.delete_branch(3, "api")
 
       branch.should be_a JSON::Any
-      branch["branch_name"].as_s.should eq "api"
+      branch.as(JSON::Any)["branch_name"].as_s.should eq "api"
+    end
+
+    it "should return true since 9.0" do
+      stub_delete("/projects/4/repository/branches/api")
+      result = client.delete_branch(4, "api")
+      result.should be_true
     end
   end
 end

--- a/spec/gitlab/client/group_spec.cr
+++ b/spec/gitlab/client/group_spec.cr
@@ -60,9 +60,16 @@ describe Gitlab::Client::Group do
     it "should return information about a deleted group" do
       stub_delete("/groups/42", "group_delete")
       group = client.delete_group(42)
+      group.should be_a JSON::Any
+      group.as(JSON::Any)["name"].as_s.should eq "Gitlab-Group"
+      group.as(JSON::Any)["path"].as_s.should eq "gitlab-group"
+    end
 
-      group["name"].as_s.should eq "Gitlab-Group"
-      group["path"].as_s.should eq "gitlab-group"
+    it "should return true since 9.0" do
+      stub_delete("/groups/44")
+      result = client.delete_group(44)
+      result.should be_true
+
     end
   end
 
@@ -174,10 +181,10 @@ describe Gitlab::Client::Group do
 
   describe ".delete_custom_attribute" do
     it "should return boolean" do
-      stub_delete("/groups/1/custom_attributes/custom_key","group_delete_custom_attribute")
+      stub_delete("/groups/1/custom_attributes/custom_key")
 
       result = client.group_delete_custom_attribute(1, "custom_key")
-      result.size.should eq 0
+      result.should be_true
     end
   end
 

--- a/spec/gitlab/client/issue_spec.cr
+++ b/spec/gitlab/client/issue_spec.cr
@@ -101,8 +101,16 @@ describe Gitlab::Client::Issue do
       stub_delete("/projects/3/issues/33", "issue")
       issue = client.delete_issue(3, 33)
 
-      issue["project_id"].as_i.should eq 3
-      issue["id"].as_i.should eq 33
+      issue.should be_a JSON::Any
+
+      issue.as(JSON::Any)["project_id"].as_i.should eq 3
+      issue.as(JSON::Any)["id"].as_i.should eq 33
+    end
+    it "should return true since 9.0" do
+      stub_delete("/projects/3/issues/34")
+      result = client.delete_issue(3, 34)
+      result.should be_true
+
     end
   end
 

--- a/spec/gitlab/client/label_spec.cr
+++ b/spec/gitlab/client/label_spec.cr
@@ -15,8 +15,15 @@ describe Gitlab::Client::Label do
     it "should return information about a deleted snippet" do
       stub_delete("/projects/3/labels", "label")
       label = client.delete_label(3, "Backlog")
+      label.should be_a(JSON::Any)
 
-      label["name"].as_s.should eq "Backlog"
+      label.as(JSON::Any)["name"].as_s.should eq "Backlog"
+    end
+
+    it "should return true since 9.0" do
+      result = stub_delete("/projects/4/labels")
+      result = client.delete_label(4, "Backlog")
+      result.should be_true
     end
   end
 

--- a/spec/gitlab/client/note_spec.cr
+++ b/spec/gitlab/client/note_spec.cr
@@ -105,8 +105,14 @@ describe Gitlab::Client::Note do
       it "should return information about a deleted issue note" do
         stub_delete("/projects/3/issues/7/notes/1201", "note")
         note = client.delete_issue_note(3, 7, 1201)
+        note.should be_a(JSON::Any)
+        note.as(JSON::Any)["id"].as_i.should eq 1201
+      end
 
-        note["id"].as_i.should eq 1201
+      it "should return true since 9.0" do
+        stub_delete("/projects/4/issues/8/notes/1203")
+        result = client.delete_issue_note(4, 8, 1203)
+        result.should be_true
       end
     end
 
@@ -114,8 +120,14 @@ describe Gitlab::Client::Note do
       it "should return information about a deleted snippet note" do
         stub_delete("/projects/3/snippets/7/notes/1201", "note")
         note = client.delete_snippet_note(3, 7, 1201)
+        note.should be_a(JSON::Any)
+        note.as(JSON::Any)["id"].as_i.should eq 1201
+      end
 
-        note["id"].as_i.should eq 1201
+      it "should return true since 9.0" do
+        stub_delete("/projects/9/snippets/7/notes/1201")
+        result = client.delete_snippet_note(9, 7, 1201)
+        result.should be_true
       end
     end
 
@@ -124,7 +136,14 @@ describe Gitlab::Client::Note do
         stub_delete("/projects/3/merge_requests/7/notes/1201", "note")
         note = client.delete_merge_request_note(3, 7, 1201)
 
-        note["id"].as_i.should eq 1201
+        note.should be_a(JSON::Any)
+        note.as(JSON::Any)["id"].as_i.should eq 1201
+      end
+
+      it "should return true since 9.0" do
+        stub_delete("/projects/13/merge_requests/7/notes/1201")
+        result = client.delete_merge_request_note(13, 7, 1201)
+        result.should be_true
       end
     end
   end

--- a/spec/gitlab/client/project_spec.cr
+++ b/spec/gitlab/client/project_spec.cr
@@ -509,10 +509,10 @@ describe Gitlab::Client::Project do
 
   describe ".delete_custom_attribute" do
     it "should return boolean" do
-      stub_delete("/projects/1/custom_attributes/custom_key","project_delete_custom_attribute")
+      stub_delete("/projects/1/custom_attributes/custom_key")
 
       result = client.project_delete_custom_attribute(1, "custom_key")
-      result.size.should eq 0
+      result.should be_true
     end
   end
 

--- a/src/gitlab/client/branch.cr
+++ b/src/gitlab/client/branch.cr
@@ -60,8 +60,10 @@ module Gitlab
       # ```
       # client.delete_branch(4, 2)
       # ```
-      def delete_branch(project_id : Int32, branch : String) : JSON::Any
-        delete("projects/#{project_id}/repository/branches/#{branch}").parse
+      def delete_branch(project_id : Int32, branch : String) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/repository/branches/#{branch}")
+        return true if response.status_code == 204
+        response.parse
       end
 
       # Protect branch in a project.

--- a/src/gitlab/client/group.cr
+++ b/src/gitlab/client/group.cr
@@ -103,8 +103,10 @@ module Gitlab
       # ```
       # client.delete_group(42)
       # ```
-      def delete_group(group_id : Int32) : JSON::Any
-        delete("groups/#{group_id}").parse
+      def delete_group(group_id : Int32) : JSON::Any | Bool
+        response = delete("groups/#{group_id}")
+        return true if response.status_code == 204
+        response.parse
       end
 
       # Search for groups by name
@@ -252,8 +254,10 @@ module Gitlab
       # ```
       # client.group_delete_custom_attribute(4, custom_key)
       # ```
-      def group_delete_custom_attribute(group_id : Int32, key : String) : JSON::Any
-        delete("groups/#{group_id.to_s}/custom_attributes/#{key}").parse
+      def group_delete_custom_attribute(group_id : Int32, key : String) : JSON::Any | Bool
+        response = delete("groups/#{group_id.to_s}/custom_attributes/#{key}")
+        return true if response.status_code == 204
+        response.parse
       end
 
 

--- a/src/gitlab/client/issue.cr
+++ b/src/gitlab/client/issue.cr
@@ -155,8 +155,10 @@ module Gitlab
       # ```
       # client.delete_issue(4, 3)
       # ```
-      def delete_issue(project_id : Int32, issue_id : Int32) : JSON::Any
-        delete("projects/#{project_id}/issues/#{issue_id}").parse
+      def delete_issue(project_id : Int32, issue_id : Int32) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/issues/#{issue_id}")
+        return true if response.status_code == 204
+        response.parse
       end
 
       # Move an issue to another project.

--- a/src/gitlab/client/label.cr
+++ b/src/gitlab/client/label.cr
@@ -71,8 +71,10 @@ module Gitlab
       # ```
       # client.delete_issue(4, 3)
       # ```
-      def delete_label(project_id : Int32, name : String) : JSON::Any
-        delete("projects/#{project_id}/labels", form: {"name" => name}).parse
+      def delete_label(project_id : Int32, name : String) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/labels", form: {"name" => name})
+        return true if response.status_code == 204
+        response.parse
       end
 
       # Subscribe a label in a project.

--- a/src/gitlab/client/merge_request.cr
+++ b/src/gitlab/client/merge_request.cr
@@ -116,8 +116,10 @@ module Gitlab
       # ```
       # client.delete_merge_request(1, 3, 6)
       # ```
-      def delete_merge_request(project_id : Int32, merge_request_id : Int32) : JSON::Any
-        delete("projects/#{project_id}/merge_requests/#{merge_request_id}").parse
+      def delete_merge_request(project_id : Int32, merge_request_id : Int32) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/merge_requests/#{merge_request_id}")
+        return true if response.status_code == 204
+        response.parse
       end
 
       # List changes of a merge request in a project.

--- a/src/gitlab/client/note.cr
+++ b/src/gitlab/client/note.cr
@@ -85,8 +85,10 @@ module Gitlab
       # ```
       # client.delete_issue_note(1, 3, 6)
       # ```
-      def delete_issue_note(project_id : Int32, issue_id : Int32, note_id : Int32) : JSON::Any
-        delete("projects/#{project_id}/issues/#{issue_id}/notes/#{note_id}").parse
+      def delete_issue_note(project_id : Int32, issue_id : Int32, note_id : Int32) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/issues/#{issue_id}/notes/#{note_id}")
+        return true if response.status_code == 204
+        response.parse
       end
 
       # Gets a list notes of snippet in a project.
@@ -161,8 +163,10 @@ module Gitlab
       # ```
       # client.delete_snippet_note(1, 3, 6)
       # ```
-      def delete_snippet_note(project_id : Int32, snippet_id : Int32, note_id : Int32) : JSON::Any
-        delete("projects/#{project_id}/snippets/#{snippet_id}/notes/#{note_id}").parse
+      def delete_snippet_note(project_id : Int32, snippet_id : Int32, note_id : Int32) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/snippets/#{snippet_id}/notes/#{note_id}")
+        return true if response.status_code == 204
+        response.parse
       end
 
       # Gets a list notes of merge request in a project.
@@ -237,8 +241,10 @@ module Gitlab
       # ```
       # client.delete_merge_request_note(1, 3, 6)
       # ```
-      def delete_merge_request_note(project_id : Int32, merge_request_id : Int32, note_id : Int32) : JSON::Any
-        delete("projects/#{project_id}/merge_requests/#{merge_request_id}/notes/#{note_id}").parse
+      def delete_merge_request_note(project_id : Int32, merge_request_id : Int32, note_id : Int32) : JSON::Any | Bool
+        response = delete("projects/#{project_id}/merge_requests/#{merge_request_id}/notes/#{note_id}")
+        return true if response.status_code == 204
+        response.parse
       end
     end
   end

--- a/src/gitlab/client/project.cr
+++ b/src/gitlab/client/project.cr
@@ -747,8 +747,10 @@ module Gitlab
       # ```
       # client.project_delete_custom_attribute(4, custom_key)
       # ```
-      def project_delete_custom_attribute(project_id : Int32, key : String) : JSON::Any
-        delete("projects/#{project_id.to_s}/custom_attributes/#{key}").parse
+      def project_delete_custom_attribute(project_id : Int32, key : String) : JSON::Any | Bool
+        response = delete("projects/#{project_id.to_s}/custom_attributes/#{key}")
+        return true if response.status_code == 204
+        response.parse
       end
 
     end

--- a/src/gitlab/client/user.cr
+++ b/src/gitlab/client/user.cr
@@ -100,7 +100,6 @@ module Gitlab
       def delete_user(user_id : Int32) : JSON::Any | Bool
         response = delete("users/#{user_id.to_s}")
         return true if response.status_code == 204
-
         response.parse
       end
 
@@ -164,9 +163,7 @@ module Gitlab
       # ```
       def user_delete_custom_attribute(user_id : Int32, key : String) : JSON::Any | Bool
         response = delete("users/#{user_id.to_s}/custom_attributes/#{key}")
-
         return true if response.status_code == 204
-
         response.parse
       end
 


### PR DESCRIPTION
I think I got them all now.
```
$ grep delete src -r | grep JSON| grep -v Bool | grep -v "#"

src/gitlab/client/merge_request.cr:      def delete_merge_request(project_id : Int32, merge_request_id : Int32) : JSON::Any
src/gitlab/client/branch.cr:      def delete_branch(project_id : Int32, branch : String) : JSON::Any
src/gitlab/client/note.cr:      def delete_issue_note(project_id : Int32, issue_id : Int32, note_id : Int32) : JSON::Any
src/gitlab/client/note.cr:      def delete_snippet_note(project_id : Int32, snippet_id : Int32, note_id : Int32) : JSON::Any
src/gitlab/client/note.cr:      def delete_merge_request_note(project_id : Int32, merge_request_id : Int32, note_id : Int32) : JSON::Any
src/gitlab/client/project.cr:      def project_delete_custom_attribute(project_id : Int32, key : String) : JSON::Any
src/gitlab/client/issue.cr:      def delete_issue(project_id : Int32, issue_id : Int32) : JSON::Any
src/gitlab/client/group.cr:      def delete_group(group_id : Int32) : JSON::Any
src/gitlab/client/group.cr:      def group_delete_custom_attribute(group_id : Int32, key : String) : JSON::Any
src/gitlab/client/label.cr:      def delete_label(project_id : Int32, name : String) : JSON::Any
```