### PR TITLE
add single custom_attribute for user, project and group

### DIFF
--- a/spec/gitlab/client/group_spec.cr
+++ b/spec/gitlab/client/group_spec.cr
@@ -161,6 +161,16 @@ describe Gitlab::Client::Group do
     end
   end
 
+  describe ".custom_attribute" do
+    it "should return a json data of single group's custom attribute" do
+      stub_get("/groups/2/custom_attribute/custom_key", "group_add_custom_attribute")
+      result = client.group_custom_attribute(2,"custom_key")
+
+      result["key"].as_s.should eq "custom_key"
+      result["value"].as_s.should eq "custom_value"
+    end
+  end
+
   describe ".add_custom_attribute" do
     it "should return boolean" do
       params = {"value" => "custom_value"}

--- a/spec/gitlab/client/project_spec.cr
+++ b/spec/gitlab/client/project_spec.cr
@@ -496,6 +496,16 @@ describe Gitlab::Client::Project do
     end
   end
 
+  describe ".custom_attribute" do
+    it "should return a json data of a single project's custom attribute" do
+      stub_get("/projects/1/custom_attribute/custom_key", "project_add_custom_attribute")
+      result = client.project_custom_attribute(1, "custom_key")
+
+      result["key"].as_s.should eq "custom_key"
+      result["value"].as_s.should eq "custom_value"
+    end
+  end
+
   describe ".add_custom_attribute" do
     it "should return boolean" do
       params = {"value" => "custom_value"}

--- a/spec/gitlab/client/user_spec.cr
+++ b/spec/gitlab/client/user_spec.cr
@@ -101,6 +101,16 @@ describe Gitlab::Client::User do
     end
   end
 
+  describe ".custom_attribute" do
+    it "should return a json data of a single user's custom attribute" do
+      stub_get("/users/2/custom_attribute/custom_key", "user_add_custom_attribute")
+      result = client.user_custom_attribute(2, "custom_key")
+
+      result["key"].as_s.should eq "custom_key"
+      result["value"].as_s.should eq "custom_value"
+    end
+  end
+
   describe ".add_custom_attribute" do
     it "should return boolean" do
       params = {"value" => "custom_value"}

--- a/src/gitlab/client/group.cr
+++ b/src/gitlab/client/group.cr
@@ -224,6 +224,21 @@ module Gitlab
         get("groups/#{group_id.to_s}/custom_attributes").parse
       end
 
+      # Gets a single group custom attribute
+      #
+      # **Available only for admin**.
+      #
+      # - param [Int32] group_id The Id of group
+      # - param [String] the key of the custom attribute
+      # - return [JSON::Any] information about the custom_attribute
+      #
+      # ```
+      # client.group_custom_attribute(4, "some_key")
+      # ```
+      def group_custom_attribute(group_id : Int32, key : String ) : JSON::Any
+        get("groups/#{group_id.to_s}/custom_attribute/#{key}").parse
+      end
+
       # Add's a group custom attribute
       #
       # **Available only for admin**.

--- a/src/gitlab/client/project.cr
+++ b/src/gitlab/client/project.cr
@@ -719,6 +719,21 @@ module Gitlab
         get("projects/#{project_id.to_s}/custom_attributes").parse
       end
 
+      # Gets a single project custom attribute
+      #
+      # **Available only for admin**.
+      #
+      # - param [Int32] project_id The Id of project
+      # - param [String] the key of the custom attribute
+      # - return [JSON::Any] information about the custom_attribute
+      #
+      # ```
+      # client.project_custom_attribute(4, "custom_key")
+      # ```
+      def project_custom_attribute(project_id : Int32, key : String ) : JSON::Any
+        get("projects/#{project_id.to_s}/custom_attribute/#{key}").parse
+      end
+
       # Add's a project custom attribute
       #
       # **Available only for admin**.

--- a/src/gitlab/client/user.cr
+++ b/src/gitlab/client/user.cr
@@ -134,6 +134,21 @@ module Gitlab
         get("users/#{user_id.to_s}/custom_attributes").parse
       end
 
+      # Gets a single user custom attribute
+      #
+      # **Available only for admin**.
+      #
+      # - param [Int32] user_id The Id of user
+      # - param [String] the key of the custom attribute
+      # - return [JSON::Any] information about the custom_attribute
+      #
+      # ```
+      # client.user_custom_attribute(4, "custom_key")
+      # ```
+      def user_custom_attribute(user_id : Int32, key : String ) : JSON::Any
+        get("users/#{user_id.to_s}/custom_attribute/#{key}").parse
+      end
+
       # Add's a user custom attribute
       #
       # **Available only for admin**.


### PR DESCRIPTION
There was one method missing. Now custom attributes are completely implemented.

Thanks!